### PR TITLE
Make it so postgres-crate can install version 9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,5 +34,9 @@
       <id>sonatype</id>
       <url>http://oss.sonatype.org/content/repositories/releases</url>
     </repository>
+    <repository>
+      <id>sonatype-snapshot</id>
+      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
   </repositories>
 </project>

--- a/src/pallet/crate/postgres.clj
+++ b/src/pallet/crate/postgres.clj
@@ -112,10 +112,10 @@
   [session version]
   (let [os-family (session/os-family session)]
     (cond
-     (and (= :debian os-family) (= "9.0" version)) :debian-backports
-     (and (= :ubuntu os-family) (= "9.0" version)) :martin-pitt-backports
-     (and (= :centos os-family) (= "9.0" version)) :pgdg
-     (and (= :fedora os-family) (= "9.0" version)) :pgdg
+     (and (= :debian os-family) (.startsWith version "9.")) :debian-backports
+     (and (= :ubuntu os-family) (.startsWith version "9.")) :martin-pitt-backports
+     (and (= :centos os-family) (.startsWith version "9.")) :pgdg
+     (and (= :fedora os-family) (.startsWith version "9.")) :pgdg
      :else :native)))
 
 (def pgdg-repo-versions


### PR DESCRIPTION
Widens the conditions in which the backports repos will be used for postgres to include versions that start with "9.". 
