### PR TITLE
Format README and partial fix for issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,67 +13,57 @@ and returns a server-spec for installing postgres.
 
 The postgres crate uses the following settings:
 
-:version
-a string to specify the point version of postgres (eg. "9.1"). The default
-is the version provided by the system's packaging system.
+* `:version`
+  a string to specify the point version of PostgreSQL (e.g., `"9.1"`). The default is the version provided by the system's packaging system
 
-:components
-a set of #{:server :libs :client}
+* `:components`
+  a set of one or more recognized keywords. The set of every component is `#{:server :libs :client}`.
+  
+* `:strategy`
+  allows override of the install strategy (`:packages`, `:package-source`, or `:rpm`)
+  
+* `:packages`
+  the packages that are used to install
+  
+* `:package-source`
+  a non-default package source for the packages
+  
+* `:rpm`
+  takes a map of [`remote-file` options](http://palletops.com/pallet/api/0.7/pallet.action.remote-file.html) specifying an RPM file to install
+  
+* `:default-cluster-name`
+  name of the default cluster created by the installer
+  
+* `:bin`
+  path to binaries
+  
+* `:owner`
+  unix owner for Postgres files
+  
+* `:postgresql_file`
+  path to `postgresql.conf`
 
-:strategy
-allows override of the install strategy (:packages, :package-source, or :rpm)
-
-:packages
-the packages that are used to install
-
-:package-source
-a non-default package source for the packages
-
-:rpm
-takes a map of remote-file options specifying a rpm file to install
-
-:default-cluster-name
-name of the default cluster created by the installer
-
-:bin
-path to binaries
-
-:owner
-unix owner for postgres files
-
-:postgresql_file
-path to postgresql.conf
-
-:has-pg-wrapper
-boolean flag for availability of a wrapper allowing command execution against
-a specified cluster
-
-:has-multicluster-service
-boolean flag specifying whether the init service is multi-cluster capable
-
-:initdb-via
-whether to use the initdb command (:initdb), or service (:service) to run initdb
-
-:options
-A map of options (See below)
-
-Options
-
-:data_directory
-Path to data storage location
-
-:hba_file
-Path to pg_hba.conf location
-
-:ident_file
-Path to pg_ident.conf location
-
-:external_pid_file
-Path to pid file
-
-:unix_socket_directory
-path to directory for unix sockets
-
+* `:has-pg-wrapper`
+  boolean flag for availability of a wrapper allowing command execution against a specified cluster.
+  
+* `:has-multicluster-service`
+  boolean flag specifying whether the init service is multi-cluster capable.
+  
+* `:initdb-via`
+  whether to use the initdb (`:initdb`), or service (`:service`) to run initdb
+  
+* `:options`
+  A map of options:
+  - `:data_directory`
+    path to storage location
+  - `:hba_file`
+    path to `pg_hba.conf` location
+  - `:ident_file`
+    path to `pg_ident.conf` location
+  - `:external_pid_file`
+    path to pid file
+  - `:unix_socket_directory`
+    path to directory for unix sockets
 
 ## Support
 

--- a/src/pallet/crate/postgres.clj
+++ b/src/pallet/crate/postgres.clj
@@ -95,7 +95,7 @@ Links:
 
 (def ^{:dynamic true} *pgdg-repo-versions*
   {"9.0" "9.0-5"
-   "9.1" "9.1-4"
+   "9.1" "9.1-5"
    "9.2" "9.2-5"})
 
 (defn pgdg-url
@@ -126,7 +126,8 @@ Links:
                (assoc settings
                  :strategy :rpm-repo
                  :rpm {:name "pgdg.rpm"
-                       :url (pgdg-url (version-string version) os)}
+                       :url (pgdg-url (version-string version)
+                                      (if (= os :rhel) "redhat" os))}
                  :packages (map
                             #(str "postgresql"
                                   (string/replace target-version "." "")


### PR DESCRIPTION
(How much detail would you like to be in the pull request, vs what's in the actual commits? Because right now I'm just going to be conservative and include all of the commit content.)
### Commit One:

Improve README formatting

Specifically:
- Display keywords and filenames in monospace
- Link to documentation for `pallet.action.remote-file`
- Display possible `postgres-settings` keys in an unordered list
### Commit Two:

Partially fix issue #2
