### PR TITLE
Actually use the settings passed to postgres

### DIFF
--- a/src/pallet/crate/postgres.clj
+++ b/src/pallet/crate/postgres.clj
@@ -1009,7 +1009,7 @@ END$$;"
   [settings]
   (server-spec
    :phases {:settings (phase-fn
-                        (postgres-settings (settings-map {})))
+                        (postgres-settings (settings-map settings)))
             :configure (phase-fn
                         (initdb)
                         (hba-conf)


### PR DESCRIPTION
The settings argument of pallet.crate.postgres/postgres was not actually
used. This patch fixes this by passing it to the existing settings-map
call instead.
